### PR TITLE
Replace cargoSha256 with lock file reference

### DIFF
--- a/maturin-nix.nix
+++ b/maturin-nix.nix
@@ -49,7 +49,7 @@ in rustPlatform.buildRustPackage rec {
 
   src = builtins.filterSource sourceFilter ./.;
 
-  cargoSha256 = "1yf9v50cl2w3xka7y2nvg9vb6nk3vb0pazss8rlv5bjxipv0672a";
+  cargoLock = { lockFile = ./Cargo.lock; };
 
   nativeBuildInputs = [ pkgconfig ];
 


### PR DESCRIPTION
The SHA is outdated, but the whole pattern can be replaced with the new direct reference to the Cargo.lock (as described [here](https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/rust.section.md)), which should be more robust.